### PR TITLE
Update version file URLs

### DIFF
--- a/GameData/4kSP/4kSP.version
+++ b/GameData/4kSP/4kSP.version
@@ -1,7 +1,7 @@
 {
   "NAME": "4kSP",
-  "URL": "https://raw.githubusercontent.com/linuxgurugamer/4kSP/master/4kSP.version",
-  "DOWNLOAD": "https://github.com/linuxgurugamer/4kSP/releases",
+  "URL": "https://raw.githubusercontent.com/linuxgurugamer/4ksp_Expanded/master/4kSP.version",
+  "DOWNLOAD": "https://github.com/linuxgurugamer/4ksp_Expanded/releases",
   "VERSION": {
     "MAJOR": 0,
     "MINOR": 2,


### PR DESCRIPTION
Hi @linuxgurugamer, the version file has some URLs that don't match the current repo name.
Now they're updated.